### PR TITLE
Allow missing batch settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # parardox-nakadi-consumer
 
-[![Build Status](https://travis-ci.org/zalando-incubator/paradox-nakadi-consumer.svg?branch=master)](https://travis-ci.org/zalando-incubator/paradox-nakadi-consumer)
-[![Coverage Status](https://codecov.io/github/zalando-incubator/paradox-nakadi-consumer/coverage.svg?branch=master)](https://codecov.io/github/zalando-incubator/paradox-nakadi-consumer?branch=master)
+[![Build Status](https://travis-ci.org/zalando-nakadi/paradox-nakadi-consumer.svg?branch=master)](https://travis-ci.org/zalando-nakadi/paradox-nakadi-consumer)
+[![Coverage Status](https://codecov.io/github/zalando-nakadi/paradox-nakadi-consumer/coverage.svg?branch=master)](https://codecov.io/github/zalando-nakadi/paradox-nakadi-consumer?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/org.zalando.paradox/paradox-nakadi-consumer-core.svg)]()
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/zalando-incubator/paradox-nakadi-consumer/master/LICENSE.txt)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/zalando-nakadi/paradox-nakadi-consumer/master/LICENSE.txt)
 
 Java high level [Nakadi](https://github.com/zalando/nakadi) consumer.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.3.4
+version=0.3.5

--- a/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/EventReceiverRegistryConfiguration.java
+++ b/paradox-nakadi-consumer-boot/src/main/java/de/zalando/paradox/nakadi/consumer/boot/EventReceiverRegistryConfiguration.java
@@ -1,6 +1,7 @@
 package de.zalando.paradox.nakadi.consumer.boot;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -94,8 +95,9 @@ public class EventReceiverRegistryConfiguration {
     }
 
     public Integer getEventsBatchTimeoutSeconds(final String consumer) {
-        return firstNonNull(getConsumerSetting(consumer).getEventsBatchTimeoutSeconds(),
-                nakadiSettings.getDefaults().getEventsBatchTimeoutSeconds());
+        return Stream.of(getConsumerSetting(consumer).getEventsBatchTimeoutSeconds(),
+                         nakadiSettings.getDefaults().getEventsBatchTimeoutSeconds()).filter(Objects::nonNull)
+                     .findFirst().orElse(null);
     }
 
     public Integer getEventsStreamLimit() {
@@ -111,8 +113,8 @@ public class EventReceiverRegistryConfiguration {
     }
 
     public Integer getEventsBatchLimit(final String consumer) {
-        return firstNonNull(getConsumerSetting(consumer).getEventsBatchLimit(),
-                nakadiSettings.getDefaults().getEventsBatchLimit());
+        return Stream.of(getConsumerSetting(consumer).getEventsBatchLimit(),
+                nakadiSettings.getDefaults().getEventsBatchLimit()).filter(Objects::nonNull).findFirst().orElse(null);
     }
 
     private NakadiConsumerSettings getConsumerSetting(final String consumer) {

--- a/paradox-nakadi-consumer-boot/src/test/java/de/zalando/paradox/nakadi/consumer/boot/EventReceiverRegistryConfigurationIT.java
+++ b/paradox-nakadi-consumer-boot/src/test/java/de/zalando/paradox/nakadi/consumer/boot/EventReceiverRegistryConfigurationIT.java
@@ -25,7 +25,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
         "paradox.nakadi.defaults.oauth2Enabled: false",                      //
         "paradox.nakadi.defaults.nakadiUrl: http://localhost:8080",          //
         "paradox.nakadi.defaults.eventsBatchLimit: 100",                     //
-        "paradox.nakadi.defaults.eventsBatchTimeoutSeconds: 5",              //
         "paradox.nakadi.consumers.testConsumer.eventsBatchLimit: 1",         //
         "paradox.nakadi.consumers.testConsumer.eventsBatchTimeoutSeconds: 1" //
     }
@@ -52,6 +51,12 @@ public class EventReceiverRegistryConfigurationIT {
         final Integer eventsBatchLimit = eventReceiverRegistryConfiguration.getEventsBatchTimeoutSeconds(
                 "testConsumer");
         assertThat(eventsBatchLimit).isEqualTo(1);
+    }
+
+    @Test
+    public void testShouldReturnNullIfBatchTimeoutSecondsNotConfigured() {
+        assertThat(eventReceiverRegistryConfiguration.getEventsBatchTimeoutSeconds("consumerWithoutBatchTimeout"))
+            .isNull();
     }
 
 }


### PR DESCRIPTION
This allows the parameters `eventsBatchTimeoutSeconds` and `eventsBatchLimit` to be missing in the application's properties file. If missing, Nakadi's defaults will be used.